### PR TITLE
Update Font Awesome Logos to FA5

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,7 @@ disqus_shortname:
 github_username: saikiransripada
 twitter_username: wp_user
 linkedin_username: saikiransripada
+dev_username: dev_user
 
 # Post sharing icons
 show_sharing_icons: true

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,6 @@
     <title>{% if page.title %}{{ page.title | strip_html }} &#8211; {% endif %}{{ site.title | strip_html }}</title>
     <link rel="dns-prefetch" href="//fonts.googleapis.com">
     <link rel="dns-prefetch" href="//fonts.gstatic.com">
-    <link rel="dns-prefetch" href="//maxcdn.bootstrapcdn.com">
     <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{% if page.meta_description %}{{ page.meta_description | xml_escape }}{% elsif page.summary %}{{ page.summary | xml_escape }}{% else %}{{ site.description | xml_escape }}{% endif %}">
@@ -22,7 +21,8 @@
     <link href='//fonts.googleapis.com/css?family=Merriweather:900,900italic,300,300italic' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Lato:900,300' rel='stylesheet' type='text/css'>
     {% if site.show_social_icons or site.show_sharing_icons %}
-      <link href="//maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css" rel="stylesheet">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/css/all.min.css">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/css/v4-shims.min.css    ">
     {% endif %}
 
     <!-- Open Graph -->

--- a/_includes/social_links.html
+++ b/_includes/social_links.html
@@ -1,16 +1,19 @@
 <div class="social-icons right">
   {% if site.linkedin_username %}
-    <a class="fa fa-linkedin" href="https://www.linkedin.com/in/{{ site.linkedin_username }}" target="_blank"></a>
+    <a class="fab fa-linkedin" href="https://www.linkedin.com/in/{{ site.linkedin_username }}" target="_blank"></a>
   {% endif %}  
   {% if site.github_username %}
-    <a class="fa fa-github" href="https://github.com/{{ site.github_username }}" target="_blank"></a>
+    <a class="fab fa-github" href="https://github.com/{{ site.github_username }}" target="_blank"></a>
   {% endif %}
   {% if site.twitter_username %}
-    <a class="fa fa-twitter" href="https://twitter.com/{{ site.twitter_username }}" target="_blank"></a>
+    <a class="fab fa-twitter" href="https://twitter.com/{{ site.twitter_username }}" target="_blank"></a>
+  {% endif %}
+  {% if site.devto_username %}
+    <a class="fab fa-dev" href="https://dev.to/{{ site.dev_username }}" target="_blank"></a>
   {% endif %}
   {% if site.email %}
-    <a class="fa fa-envelope" href="mailto:{{ site.email }}"></a>
+    <a class="fas fa-envelope" href="mailto:{{ site.email }}"></a>
   {% endif %}
-  <a class="fa fa-rss" href="{{ "/feed.xml" | relative_url }}" target="_blank"></a>
+  <a class="fas fa-rss" href="{{ "/feed.xml" | relative_url }}" target="_blank"></a>
 </div>
 <div class="clearfix"></div>


### PR DESCRIPTION
Hey - great template, 

Went to add "fab fa-dev" and noticed it was running FontAwesome4, updated to 5,

Removed the old FA dependency and added a Cloudflare CDN for fa5, updated the icons to find the new style fab/fas

And added a new item to the config for [dev.to](https://dev.to) usernames as a button in the footer, similar to twitter